### PR TITLE
moved keyboardLayoutGuide creation to setView method

### DIFF
--- a/JPSKeyboardLayoutGuide/JPSKeyboardLayoutGuideViewController.m
+++ b/JPSKeyboardLayoutGuide/JPSKeyboardLayoutGuideViewController.m
@@ -25,30 +25,11 @@
 	[self.view addSubview:(UIView *)self.keyboardLayoutGuide];
 }
 
--(instancetype)init
+-(void)setView:(UIView *)view
 {
-	if(self = [super init]){
-		[self _createKeyboardLayoutGuide];
-	}
-	return self;
+	[super setView:view];
+	[self _createKeyboardLayoutGuide];
 }
-
--(id)initWithCoder:(NSCoder *)aDecoder
-{
-	if(self = [super initWithCoder:aDecoder]){
-		[self _createKeyboardLayoutGuide];
-	}
-	return self;
-}
-
--(instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
-{
-	if(self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil]){
-		[self _createKeyboardLayoutGuide];
-	}
-	return self;
-}
-
 
 - (void)viewDidLoad {
     [super viewDidLoad];


### PR DESCRIPTION
To more closely mimic apple's top/bottomLayoutGuide behaviour, keyboardLayoutGuide is now created and inserted into the view hierarchy in the setView: method. This allows for using keyboardLayoutGuide earlier on in the view controller lifecycle, for example in the loadView method after setting self.view.
